### PR TITLE
feat(ui): render MITRE F3 in threat path detail view

### DIFF
--- a/app.js
+++ b/app.js
@@ -774,6 +774,7 @@
         const fraudTypes = item.fraud_types || [];
         const tags = item.tags || [];
         const ft3 = item.ft3_tactics || [];
+        const f3 = item.mitre_f3 || [];
         const ucff = item.ucff_domains || {};
 
         let html = '';
@@ -821,6 +822,7 @@
         html += '<div class="taxonomy-toggle" id="taxonomy-toggle">';
         html += '<button class="tax-btn' + (activeTaxonomy === 'cfpf' ? ' active' : '') + '" data-taxonomy="cfpf">CFPF Phases</button>';
         html += '<button class="tax-btn' + (activeTaxonomy === 'mitre' ? ' active' : '') + '" data-taxonomy="mitre">MITRE ATT&CK</button>';
+        html += '<button class="tax-btn' + (activeTaxonomy === 'f3' ? ' active' : '') + '" data-taxonomy="f3">MITRE F3</button>';
         html += '<button class="tax-btn' + (activeTaxonomy === 'groupib' ? ' active' : '') + '" data-taxonomy="groupib">Group-IB</button>';
         html += '</div>';
 
@@ -829,6 +831,8 @@
             html += renderCfpfTimeline(phases);
         } else if (activeTaxonomy === 'mitre') {
             html += renderMitreView(mitre);
+        } else if (activeTaxonomy === 'f3') {
+            html += renderMitreF3View(f3);
         } else if (activeTaxonomy === 'groupib') {
             html += renderGroupibView(groupib);
         }
@@ -859,6 +863,11 @@
         if (ft3.length > 0) {
             html += '<div class="tag-group"><h4>Stripe FT3</h4><div class="tag-list">';
             ft3.forEach(function (t) { html += '<span class="detail-tag ft3-tag">' + escapeHtml(t) + '</span>'; });
+            html += '</div></div>';
+        }
+        if (f3.length > 0 && activeTaxonomy !== 'f3') {
+            html += '<div class="tag-group"><h4>MITRE F3</h4><div class="tag-list">';
+            f3.forEach(function (t) { html += '<span class="detail-tag f3-tag">' + escapeHtml(t) + '</span>'; });
             html += '</div></div>';
         }
         // UCFF domains — render only domains with non-empty values, in lifecycle order
@@ -1099,6 +1108,27 @@
             html += '<span class="mitre-id">' + escapeHtml(t) + '</span>';
             html += '<span class="mitre-link-icon">↗</span>';
             html += '</a>';
+        });
+        html += '</div>';
+        return html;
+    }
+
+    function renderMitreF3View(techniques) {
+        if (techniques.length === 0) {
+            return '<div class="taxonomy-empty">No MITRE F3 mappings for this threat path.</div>';
+        }
+        let html = '<div class="mitre-grid">';
+        techniques.forEach(function (t) {
+            if (/^T\d/.test(t)) {
+                html += '<a class="mitre-card f3-card" href="https://attack.mitre.org/techniques/' + encodeURIComponent(t.replace('.', '/')) + '/" target="_blank" rel="noopener">';
+                html += '<span class="mitre-id">' + escapeHtml(t) + '</span>';
+                html += '<span class="mitre-link-icon">↗</span>';
+                html += '</a>';
+            } else {
+                html += '<span class="mitre-card f3-card f3-card-native">';
+                html += '<span class="mitre-id">' + escapeHtml(t) + '</span>';
+                html += '</span>';
+            }
         });
         html += '</div>';
         return html;

--- a/style.css
+++ b/style.css
@@ -35,6 +35,7 @@
     --color-mitre: #a78bfa;
     --color-groupib: #34d399;
     --color-ft3: #fbbf24;
+    --color-f3: #f97316;
     --color-ucff: #06b6d4;
     --color-general: #64748b;
     --color-success: #22c55e;
@@ -1295,6 +1296,27 @@ h4 {
 .detail-tag.ft3-tag {
     background: rgba(251, 191, 36, 0.12);
     color: var(--color-ft3);
+}
+
+.detail-tag.f3-tag {
+    background: rgba(249, 115, 22, 0.12);
+    color: var(--color-f3);
+    font-family: 'JetBrains Mono', monospace;
+}
+
+.mitre-card.f3-card {
+    color: var(--color-f3);
+    border-color: rgba(249, 115, 22, 0.25);
+}
+
+.mitre-card.f3-card:hover {
+    border-color: var(--color-f3);
+    background: rgba(249, 115, 22, 0.08);
+    color: var(--color-f3);
+}
+
+.mitre-card.f3-card-native {
+    cursor: default;
 }
 
 .detail-tag.ucff-tag {


### PR DESCRIPTION
## Summary

Commit 039b655 populated `mitre_f3` across 72 of 85 threat paths, but the frontend never rendered the field — `renderDetailView` only consumed `mitre_attack`, `ft3_tactics`, `groupib_stages`, etc. As a result, F3 data was invisible on flameintel.org (reproducible by opening TP-0001, which has 10 F3 techniques mapped).

This PR wires the existing F3 data into the detail view:

- `app.js:777` — read `item.mitre_f3`
- `app.js:825` — add "MITRE F3" button to the taxonomy toggle
- `app.js:834` — dispatch `activeTaxonomy === 'f3'` to a new `renderMitreF3View`
- `app.js:868` — fallback F3 tag group (shown when another taxonomy tab is active)
- `app.js:1116` — `renderMitreF3View`: T-prefixed (ATT&CK-derived) techniques link to `attack.mitre.org`; F1xxx F3-native techniques render as styled badges (no canonical per-technique F3 URL is referenced in the repo, so no guessed links)
- `style.css` — new `--color-f3` (#f97316), `.detail-tag.f3-tag`, and `.mitre-card.f3-card` styles

No changes to data pipelines, exports, or detection logic — UI-only.

## Test plan

- [ ] Serve the site locally and open TP-0001; confirm a "MITRE F3" tab appears next to CFPF / MITRE ATT&CK / Group-IB
- [ ] Click the F3 tab; confirm 10 cards render (`F1006.002`, `F1025.002`, `F1032`, `F1034`, `F1040.002`, `T1110.001`, `T1555`, `F1004`, `F1016`, `F1031`)
- [ ] Confirm `T1110.001` and `T1555` are clickable and open `attack.mitre.org/techniques/T1110/001/` and `.../T1555/` in a new tab
- [ ] Confirm F1xxx entries render as non-clickable badges
- [ ] Open a TP with `mitre_f3: []` (one of the 13 infrastructure-focused TPs); confirm the F3 tab shows the "No MITRE F3 mappings…" empty state
- [ ] Switch to another taxonomy tab; confirm the fallback "MITRE F3" tag group appears in the taxonomy tags section
- [ ] Visual check: F3 orange (#f97316) is distinguishable from MITRE ATT&CK purple and Stripe FT3 amber