### PR TITLE
fix(ui): link F3 techniques to ctid.mitre.org/fraud portal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1119,16 +1119,10 @@
         }
         let html = '<div class="mitre-grid">';
         techniques.forEach(function (t) {
-            if (/^T\d/.test(t)) {
-                html += '<a class="mitre-card f3-card" href="https://attack.mitre.org/techniques/' + encodeURIComponent(t.replace('.', '/')) + '/" target="_blank" rel="noopener">';
-                html += '<span class="mitre-id">' + escapeHtml(t) + '</span>';
-                html += '<span class="mitre-link-icon">↗</span>';
-                html += '</a>';
-            } else {
-                html += '<span class="mitre-card f3-card f3-card-native">';
-                html += '<span class="mitre-id">' + escapeHtml(t) + '</span>';
-                html += '</span>';
-            }
+            html += '<a class="mitre-card f3-card" href="https://ctid.mitre.org/fraud#/technique/' + encodeURIComponent(t) + '" target="_blank" rel="noopener">';
+            html += '<span class="mitre-id">' + escapeHtml(t) + '</span>';
+            html += '<span class="mitre-link-icon">↗</span>';
+            html += '</a>';
         });
         html += '</div>';
         return html;

--- a/style.css
+++ b/style.css
@@ -1315,10 +1315,6 @@ h4 {
     color: var(--color-f3);
 }
 
-.mitre-card.f3-card-native {
-    cursor: default;
-}
-
 .detail-tag.ucff-tag {
     background: rgba(6, 182, 212, 0.12);
     color: var(--color-ucff);


### PR DESCRIPTION
## Summary

Follow-up to #64. After that PR merged, we noticed F3 links pointed at the wrong place:

- T-prefixed (ATT&CK-reused) F3 entries routed to `attack.mitre.org` — correct portal for ATT&CK, wrong portal for F3
- F-prefixed (F3-native) F3 entries rendered as non-clickable badges — no deep link at all

The canonical F3 portal is `https://ctid.mitre.org/fraud`, a hash-routed SPA with per-technique deep links at `#/technique/<ID>` (e.g. [F1006.002](https://ctid.mitre.org/fraud#/technique/F1006.002)).

This PR routes **all** F3 cards — both `F1xxx` and `Txxxx` — to the F3 portal. The MITRE ATT&CK tab still points to `attack.mitre.org`; only the F3 tab changes. Same T-prefixed ID can now appear under both tabs and deep-link to the appropriate portal for each framework.

Also drops the unused `.mitre-card.f3-card-native` CSS selector (no longer any non-clickable F3 cards).

## Test plan

- [ ] Open TP-0005 on a deploy preview, click the MITRE F3 tab
- [ ] Click `F1006.002` — confirm it opens `https://ctid.mitre.org/fraud#/technique/F1006.002` and lands on the technique page
- [ ] Click `T1110.001` under F3 — confirm it opens `https://ctid.mitre.org/fraud#/technique/T1110.001` and resolves (if the F3 portal doesn't host T-prefixed pages, we may need to route those back to attack.mitre.org — flag if broken)
- [ ] Switch to MITRE ATT&CK tab — confirm those cards still go to `attack.mitre.org/techniques/...`
- [ ] Visual regression: F3 cards still render orange (#f97316), hover state still shows the orange border